### PR TITLE
Support set base path, and change key use AsRef<str> to support multiple string types

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fn main() {
 
     // simple interaction
     db.put("simple", 1);
-    print("{}", db.get("simple").unwrap());
+    print("{}", db.get_unwrap("simple").unwrap());
     db.delete("simple");
 
     // more complex interaction
@@ -97,7 +97,8 @@ fn main() {
         sensitive_data: String::from("something_important_here")
     };
     db.put("complex", identity);
-    print("{:?}", db.get::<Identity>("complex").unwrap());
+    let stored_identity: Identity = db.get_unwrap("complex").unwrap();
+    println!("{:?}", stored_identity);
     db.delete("complex");
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ struct Identity {
 }
 
 
-fn main() -> {
+fn main() {
     let unsafe_pwd: String = "my_password_123";
 
     // initialize database with (unsafe) cleartext password
@@ -87,7 +87,7 @@ fn main() -> {
 
     // simple interaction
     db.put("simple", 1);
-    print("{}", db.get::<i32>("simple").unwrap());
+    print("{}", db.get("simple").unwrap());
     db.delete("simple");
 
     // more complex interaction

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -134,8 +134,8 @@ fn run() -> Result<()> {
         ("get", Some(subargs)) => {
             let key: &str = subargs.value_of("key").unwrap();
 
-            let value: String = kv.get(key)?;
-            println!("{}", value);
+            let value: Option<String> = kv.get(key)?;
+            println!("{}", value.unwrap_or("<None>".to_string()));
         }
         ("rm", Some(subargs)) => {
             let key: &str = subargs.value_of("key").unwrap();

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -196,7 +196,7 @@ impl MicroKV {
     ///////////////////////////////////////
 
     /// unsafe get, may this api can change name to get_unwrap
-    pub fn get<K: AsRef<str>, V>(&self, _key: K) -> Result<V>
+    pub fn get_unwrap<K: AsRef<str>, V>(&self, _key: K) -> Result<V>
     where
         V: DeserializeOwned + 'static,
     {
@@ -211,7 +211,7 @@ impl MicroKV {
 
     /// Decrypts and retrieves a value. Can return errors if lock is poisoned,
     /// ciphertext decryption doesn't work, and if parsing bytes fail.
-    pub fn get_option<K: AsRef<str>, V>(&self, _key: K) -> Result<Option<V>>
+    pub fn get<K: AsRef<str>, V>(&self, _key: K) -> Result<Option<V>>
     where
         V: DeserializeOwned + 'static,
     {

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -21,7 +21,7 @@
 //! kv.put("keyname", &value);
 //!
 //! // get
-//! let res: i32 = kv.get("keyname").expect("cannot retrieve value");
+//! let res: i32 = kv.get_unwrap("keyname").expect("cannot retrieve value");
 //! println!("{}", res);
 //!
 //! // delete
@@ -33,7 +33,7 @@ use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use indexmap::IndexMap;
 use secstr::{SecStr, SecVec};
@@ -200,7 +200,7 @@ impl MicroKV {
     where
         V: DeserializeOwned + 'static,
     {
-        if let Some(v) = self.get_option(_key)? {
+        if let Some(v) = self.get(_key)? {
             return Ok(v);
         }
         Err(KVError {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -88,6 +88,7 @@ fn test_base_path_with_auto_commit() {
     kv.put(KEY_NAME, &value).expect("cannot insert value");
 
     // get key and validate
-    let res: String = kv.get(KEY_NAME).expect("cannot retrieve value");
-    assert_eq!(value, res);
+    let res: Option<String> = kv.get_option(KEY_NAME).expect("cannot retrieve value");
+    println!("{:?}", res);
+    assert_eq!(Some(value), res);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,7 +30,7 @@ fn test_simple_integral() {
     kv.put(KEY_NAME, &value).expect("cannot insert value");
 
     // get key and validate
-    let res: u64 = kv.get(KEY_NAME).expect("cannot retrieve value");
+    let res: u64 = kv.get_unwrap(KEY_NAME).expect("cannot retrieve value");
     assert_eq!(value, res);
 
     // delete value
@@ -41,7 +41,7 @@ fn test_simple_integral() {
     kv.put(KEY_NAME, &value).expect("cannot insert value");
 
     // get key and validate
-    let res: i32 = kv.get(KEY_NAME).expect("cannot retrieve value");
+    let res: i32 = kv.get_unwrap(KEY_NAME).expect("cannot retrieve value");
     assert_eq!(value, res);
 }
 
@@ -54,7 +54,7 @@ fn test_simple_string() {
     kv.put(KEY_NAME, &value).expect("cannot insert value");
 
     // get key and validate
-    let res: String = kv.get(KEY_NAME).expect("cannot retrieve value");
+    let res: String = kv.get_unwrap(KEY_NAME).expect("cannot retrieve value");
     assert_eq!(value, res);
 }
 
@@ -68,7 +68,7 @@ fn test_complex_struct() {
     };
     kv.put(KEY_NAME, &value).expect("cannot insert value");
 
-    let res: TestStruct = kv.get(KEY_NAME).expect("cannot retrieve value");
+    let res: TestStruct = kv.get_unwrap(KEY_NAME).expect("cannot retrieve value");
     assert_eq!(value.id, res.id);
     assert_eq!(value.name, res.name);
 }
@@ -88,7 +88,7 @@ fn test_base_path_with_auto_commit() {
     kv.put(KEY_NAME, &value).expect("cannot insert value");
 
     // get key and validate
-    let res: Option<String> = kv.get_option(KEY_NAME).expect("cannot retrieve value");
+    let res: Option<String> = kv.get(KEY_NAME).expect("cannot retrieve value");
     println!("{:?}", res);
     assert_eq!(Some(value), res);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,9 +4,11 @@
 //! - simple database interactions
 //! - concurrent database interactions
 
-use microkv::MicroKV;
+use std::env;
 
 use serde::{Deserialize, Serialize};
+
+use microkv::MicroKV;
 
 // constants used throughout each test case
 static KEY_NAME: &str = "some_key";
@@ -69,4 +71,23 @@ fn test_complex_struct() {
     let res: TestStruct = kv.get(KEY_NAME).expect("cannot retrieve value");
     assert_eq!(value.id, res.id);
     assert_eq!(value.name, res.name);
+}
+
+#[test]
+fn test_base_path_with_auto_commit() {
+    let mut dir = env::temp_dir();
+    dir.push("microkv");
+
+    let kv: MicroKV = MicroKV::open_with_base_path("test_base_path_with_auto_commit", dir)
+        .expect("Failed to create MicroKV from a stored file or create MicroKV for this file")
+        .set_auto_commit(true)
+        .with_pwd_clear(TEST_PASSWORD.to_string());
+
+    // insert String value
+    let value: String = String::from("my value");
+    kv.put(KEY_NAME, &value).expect("cannot insert value");
+
+    // get key and validate
+    let res: String = kv.get(KEY_NAME).expect("cannot retrieve value");
+    assert_eq!(value, res);
 }


### PR DESCRIPTION
Some OS not have HOME environment, like windows. or want sore file to special path. so this pr add some new api to set it.

- new_with_base_path
- open_with_base_path

And change store key from `&str` to `AsRef<str>`, this way help to simple to use these api. multiple string can be set  `&str` `String` `OsString` ...

support auto commit
