### PR TITLE
Derive clone

### DIFF
--- a/src/kv.rs
+++ b/src/kv.rs
@@ -55,7 +55,7 @@ type KV = IndexMap<String, SecVec<u8>>;
 
 /// Defines the main interface structure to represent the most
 /// recent state of the data store.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct MicroKV {
     path: PathBuf,
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,6 @@
 //! - simple database interactions
 //! - concurrent database interactions
 
-use std::sync::Arc;
 use std::{env, thread};
 
 use serde::{Deserialize, Serialize};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -120,4 +120,12 @@ fn test_multiple_thread() {
     for thread in threads {
         thread.join().unwrap();
     }
+    for ix in 0..1000 {
+        let except_key = format!("key-thread-{}", ix);
+        let except_value = format!("value-thread-{}", ix);
+        let real_value: String = kv
+            .get_unwrap(except_key)
+            .expect("failed to get value from MicroKV");
+        assert_eq!(real_value, except_value);
+    }
 }


### PR DESCRIPTION
Derive clone, support multiple runtime/thread.

for example:
when we create a system have multiple threads, but all thread share global state, this state include microkv, now we need microkv support `Clone` send to all thread.
> Maybe also need `Send` + `Sync` ? not currently needed, add if necessary.

I think need derive it, and I wrote a test in playground,
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=62d4ef3361532d074676ab37d28b003d
and add a new test `test_multiple_thread`
It's work's. if you have any questions, you can tell me, I'll change it.

the reason for not using borrowing is that the lifetime makes the code very complicated.

