### PR TITLE
Add serialize trait to get value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = ["cli"]
 [dependencies]
 bincode = "1.2.1"
 sodiumoxide = "0.2.5"
+dirs = "3"
 
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 serde = { version = "1.0", features = ["rc", "derive"] }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -246,7 +246,7 @@ impl MicroKV {
     /// unsafe get, may this api can change name to get_unwrap
     pub fn get_unwrap<V>(&self, key: impl AsRef<str>) -> Result<V>
     where
-        V: DeserializeOwned + 'static,
+        V: Serialize + DeserializeOwned + 'static,
     {
         self.namespace_default().get_unwrap(key)
     }
@@ -255,7 +255,7 @@ impl MicroKV {
     /// ciphertext decryption doesn't work, and if parsing bytes fail.
     pub fn get<V>(&self, key: impl AsRef<str>) -> Result<Option<V>>
     where
-        V: DeserializeOwned + 'static,
+        V: Serialize + DeserializeOwned + 'static,
     {
         self.namespace_default().get(key)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod errors;
 pub mod kv;
+pub mod namespace;
 
 // re-import for accessible namespace
 pub use self::kv::MicroKV;

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,0 +1,267 @@
+use secstr::SecVec;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sodiumoxide::crypto::secretbox::{self, Key};
+
+use crate::errors::{ErrorType, KVError, Result};
+use crate::MicroKV;
+
+// Debug,
+#[derive(Clone)]
+pub struct NamespaceMicrokv<'a> {
+    /// namespace
+    namespace: String,
+    /// stores the actual key-value store encapsulated with a RwLock
+    microkv: &'a MicroKV,
+}
+
+impl<'a> NamespaceMicrokv<'a> {
+    pub fn new(namespace: impl AsRef<str>, microkv: &'a MicroKV) -> Self {
+        Self {
+            namespace: namespace.as_ref().to_string(),
+            microkv,
+        }
+    }
+
+    fn namespace_prefix(&self) -> String {
+        format!("{}@", self.namespace)
+    }
+
+    fn key(&self, key: impl AsRef<str>) -> String {
+        if self.namespace.is_empty() {
+            key.as_ref().to_string()
+        } else {
+            format!("{}{}", &self.namespace_prefix(), key.as_ref())
+        }
+    }
+}
+
+impl<'a> NamespaceMicrokv<'a> {
+    /// unsafe get, may this api can change name to get_unwrap
+    pub fn get_unwrap<V>(&self, key: impl AsRef<str>) -> Result<V>
+    where
+        V: DeserializeOwned + 'static,
+    {
+        if let Some(v) = self.get(key)? {
+            return Ok(v);
+        }
+        Err(KVError {
+            error: ErrorType::KVError,
+            msg: Some("key not found in storage".to_string()),
+        })
+    }
+
+    /// Decrypts and retrieves a value. Can return errors if lock is poisoned,
+    /// ciphertext decryption doesn't work, and if parsing bytes fail.
+    pub fn get<V>(&self, key: impl AsRef<str>) -> Result<Option<V>>
+    where
+        V: DeserializeOwned + 'static,
+    {
+        let data_key = self.key(key);
+        let lock = self.microkv.storage().read().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+
+        // initialize a copy of state
+        let data = lock.clone();
+
+        // retrieve value from IndexMap if stored, decrypt and return
+        match data.get(&data_key) {
+            Some(val) => {
+                // get value to deserialize. If password is set, retrieve the value, and decrypt it
+                // using AEAD. Otherwise just get the value and return
+                let deser_val = match &self.microkv.pwd() {
+                    Some(pwd) => {
+                        // initialize key from pwd slice
+                        let key = match Key::from_slice(pwd.unsecure()) {
+                            Some(k) => k,
+                            None => {
+                                return Err(KVError {
+                                    error: ErrorType::CryptoError,
+                                    msg: Some("cannot derive key from password hash".to_string()),
+                                });
+                            }
+                        };
+
+                        // borrow secured value by reference, and decrypt before deserializing
+                        match secretbox::open(val.unsecure(), self.microkv.nonce(), &key) {
+                            Ok(r) => r,
+                            Err(_) => {
+                                return Err(KVError {
+                                    error: ErrorType::CryptoError,
+                                    msg: Some("cannot validate value being decrypted".to_string()),
+                                });
+                            }
+                        }
+                    }
+
+                    // if no password, return value as-is
+                    None => val.unsecure().to_vec(),
+                };
+
+                // finally deserialize into deserializable object to return as
+                let value: V = bincode::deserialize(&deser_val).map_err(|_| KVError {
+                    error: ErrorType::KVError,
+                    msg: Some("cannot deserialize into specified object type".to_string()),
+                })?;
+                Ok(Some(value))
+            }
+
+            None => Ok(None),
+        }
+    }
+
+    /// Encrypts and adds a new key-value pair to storage.
+    pub fn put<V>(&self, key: impl AsRef<str>, value: &V) -> Result<()>
+    where
+        V: Serialize,
+    {
+        let data_key = self.key(key);
+        let mut data = self.microkv.storage().write().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+
+        // to retain best-case constant runtime, we remove the key-value if found
+        if data.contains_key(&data_key) {
+            let _ = data.remove(&data_key).unwrap();
+        }
+
+        // serialize the object for committing to db
+        let ser_val: Vec<u8> = bincode::serialize(&value).unwrap();
+
+        // encrypt and secure value if password is available
+        let value: SecVec<u8> = match self.microkv.pwd() {
+            // encrypt using AEAD and secure memory
+            Some(pwd) => {
+                let key: Key = Key::from_slice(&pwd.unsecure()).unwrap();
+                SecVec::new(secretbox::seal(&ser_val, self.microkv.nonce(), &key))
+            }
+
+            // otherwise initialize secure serialized object to insert to BTreeMap
+            None => SecVec::new(ser_val),
+        };
+        data.insert(data_key, value);
+
+        if !self.microkv.is_auto_commit() {
+            return Ok(());
+        }
+        drop(data);
+        self.microkv.commit()
+    }
+
+    /// Delete removes an entry in the key value store.
+    pub fn delete(&self, key: impl AsRef<str>) -> Result<()> {
+        let data_key = self.key(key);
+        let mut data = self.microkv.storage().write().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+
+        // delete entry from BTreeMap by key
+        let _ = data.remove(&data_key);
+
+        if !self.microkv.is_auto_commit() {
+            return Ok(());
+        }
+        drop(data);
+        self.microkv.commit()
+    }
+
+    /// Helper routine that acquires a reader lock and checks if a key exists.
+    pub fn exists(&self, key: impl AsRef<str>) -> Result<bool> {
+        let data_key = self.key(key);
+        let data = self.microkv.storage().read().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+        Ok(data.contains_key(&data_key))
+    }
+
+    /// Safely consumes an iterator over the keys in the `IndexMap` and returns a
+    /// `Vec<String>` for further use.
+    ///
+    /// Note that key iteration, not value iteration, is only supported in order to preserve
+    /// security guarentees.
+    pub fn keys(&self) -> Result<Vec<String>> {
+        let lock = self.microkv.storage().read().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+
+        // initialize a copy to data
+        let data = lock.clone();
+        let keys = data
+            .keys()
+            .filter(|x| {
+                if self.namespace.is_empty() {
+                    return true;
+                }
+                x.starts_with(&self.namespace_prefix())
+            })
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        Ok(keys)
+    }
+
+    /// Safely consumes an iterator over a copy of in-place sorted keys in the
+    /// `IndexMap` and returns a `Vec<String>` for further use.
+    ///
+    /// Note that key iteration, not value iteration, is only supported in order to preserve
+    /// security guarentees.
+    pub fn sorted_keys(&self) -> Result<Vec<String>> {
+        let lock = self.microkv.storage().read().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+
+        // initialize a copy to data, and sort keys in-place
+        let mut data = lock.clone();
+        data.sort_keys();
+        let keys = data
+            .keys()
+            .filter(|x| {
+                if self.namespace.is_empty() {
+                    return true;
+                }
+                x.starts_with(&self.namespace_prefix())
+            })
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        Ok(keys)
+    }
+
+    /// Empties out the entire underlying `IndexMap` in O(n) time, but does
+    /// not delete the persistent storage file from disk. The `IndexMap` remains,
+    /// and its capacity is kept the same.
+    pub fn clear(&self) -> Result<()> {
+        let mut data = self.microkv.storage().write().map_err(|_| KVError {
+            error: ErrorType::PoisonError,
+            msg: None,
+        })?;
+
+        // first, iterate over the IndexMap and coerce drop on the secure value wrappers
+        data.iter_mut()
+            .filter(|(key, _)| {
+                if self.namespace.is_empty() {
+                    return true;
+                }
+                key.starts_with(&self.namespace_prefix())
+            })
+            .for_each(|(_, value)| value.zero_out());
+
+        // next, clear all entries from the IndexMap
+        if self.namespace.is_empty() {
+            data.clear();
+        } else {
+            data.retain(|key, _| !key.starts_with(&self.namespace_prefix()));
+        }
+
+        // auto commit
+        if !self.microkv.is_auto_commit() {
+            return Ok(());
+        }
+        self.microkv.commit()
+    }
+}

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -40,7 +40,7 @@ impl<'a> NamespaceMicrokv<'a> {
     /// unsafe get, may this api can change name to get_unwrap
     pub fn get_unwrap<V>(&self, key: impl AsRef<str>) -> Result<V>
     where
-        V: DeserializeOwned + 'static,
+        V: Serialize + DeserializeOwned + 'static,
     {
         if let Some(v) = self.get(key)? {
             return Ok(v);
@@ -55,7 +55,7 @@ impl<'a> NamespaceMicrokv<'a> {
     /// ciphertext decryption doesn't work, and if parsing bytes fail.
     pub fn get<V>(&self, key: impl AsRef<str>) -> Result<Option<V>>
     where
-        V: DeserializeOwned + 'static,
+        V: Serialize + DeserializeOwned + 'static,
     {
         let data_key = self.key(key);
         let lock = self.microkv.storage().read().map_err(|_| KVError {


### PR DESCRIPTION
Sometimes the value is not necessarily fixed and similar. After adding serialize, you can use serde to serialize it to what you want.
like there

https://github.com/darwinia-network/bridger/blob/d87e725a3c0c1d145f9a99104f47964050498ddb/bin/src/route/kv.rs#L43

The server query from microkv, and response data to client, maybe any types, so there can be serialize to `serde_json::Value`, need add `Serialize` to there.

> This pull request is include https://github.com/ex0dus-0x/microkv/pull/10, I think the namespace is important. so please consider merging first #10  
