### PR TITLE
Make KV public

### DIFF
--- a/src/kv.rs
+++ b/src/kv.rs
@@ -71,7 +71,7 @@ const DEFAULT_WORKSPACE_PATH: &str = ".microkv/";
 /// An alias to a base data structure that supports storing
 /// associated types. An `IndexMap` is a strong choice due to
 /// strong asymptotic performance with sorted key iteration.
-type KV = IndexMap<String, SecVec<u8>>;
+pub type KV = IndexMap<String, SecVec<u8>>;
 
 /// Defines the main interface structure to represent the most
 /// recent state of the data store.


### PR DESCRIPTION
Now that we have implemented this nice lock function and added functionality to it (i.e., auto-commit etc.), it makes sense to set KV to public.

Image the scenario, where we want to create a function that is applied on such a lock to use it multiple times:

```
check_something_before_insert(kv: ???, data: &str) {
  data == "test"
}

db.lock_write(|kv| {
  if check_something_before_insert(kv, "test") {
    kv.kv_put(...);
  }
});

db.lock_write(|kv| {
  if check_something_before_insert(kv, "another_test") {
    kv.kv_put(...);
  }
});
```

Such a functionality is not possible since the KV datatype is not public. I thus propose with this PR to make it public such that those use cases become possible. What is your opinion on this matter? If you have a better idea, I'd love to discuss it.

(Of course the user could also implement this type themselves, but then they would need to add the secstr dependency and keep it in sync with the version used in microkv)